### PR TITLE
Format job summary as a code block

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           script_file: 'example_script.py'
           daft_version: 'latest'
-      - name: Show job summary
+      - name: Show job summary (formatted as a code block)
         run: |
           echo -e "\`\`\`\n${{ steps.run_script.outputs.result }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run Daft script from file
-        uses: peckjon/daft-script@v1
+        uses: peckjon/daft-script@v1.0.1
         with:
           script_file: 'scripts/process_data.py'
           # Optional: specify a specific Daft version


### PR DESCRIPTION
In job summary, add backticks around script output to format as a code block